### PR TITLE
[nextjs] add initial chart

### DIFF
--- a/charts/nextjs/.helmignore
+++ b/charts/nextjs/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/nextjs/Chart.yaml
+++ b/charts/nextjs/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: nextjs
+description: A chart for NextJS v10+.
+icon: https://cdn.worldvectorlogo.com/logos/next-js.svg
+version: 0.1.0
+appVersion: 10.0.5
+type: application
+keywords:
+  - nextjs
+maintainers:
+  - name: ellisio
+    email: aellis@fluidtruck.com

--- a/charts/nextjs/README.md
+++ b/charts/nextjs/README.md
@@ -1,0 +1,109 @@
+# nextjs
+
+Installs a [nextjs](https://nextjs.org) image onto a Kubernetes cluster.
+
+## Prerequisites
+
+- Kubernetes 1.17+
+- Helm 3+
+
+## Get Repo Info
+
+```console
+helm repo add fluidshare https://fluidshare.github.io/helm-charts
+helm repo update
+```
+
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+
+## Install Chart
+
+```console
+# Helm
+$ helm install [RELEASE_NAME] fluidshare/nextjs
+```
+
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Uninstall Chart
+
+```console
+# Helm
+$ helm uninstall [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Chart
+
+```console
+# Helm
+$ helm upgrade [RELEASE_NAME] fluidshare/nextjs
+```
+
+With Helm v3, CRDs created by this chart are not updated by default and should be manually updated.
+Consult also the [Helm Documentation on CRDs](https://helm.sh/docs/chart_best_practices/custom_resource_definitions).
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+### Upgrading an existing Release to a new major version
+
+A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an incompatible breaking change needing manual actions.
+
+### From 1.x to 2.x
+
+This has not happened yet; so a placeholder will exist here until then.
+
+## Configuration
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments:
+
+```console
+helm show values fluidshare/kube-prometheus-stack
+```
+
+You may also `helm show values` on this chart's [dependencies](#dependencies) for additional options.
+
+## Work-Arounds for Known Issues
+
+## PrometheusRules Admission Webhooks
+
+With Prometheus Operator version 0.30+, the core Prometheus Operator pod exposes an endpoint that will integrate with the `validatingwebhookconfiguration` Kubernetes feature to prevent malformed rules from being added to the cluster.
+
+### How the Chart Configures the Hooks
+
+A validating and mutating webhook configuration requires the endpoint to which the request is sent to use TLS. It is possible to set up custom certificates to do this, but in most cases, a self-signed certificate is enough. The setup of this component requires some more complex orchestration when using helm. The steps are created to be idempotent and to allow turning the feature on and off without running into helm quirks.
+
+1. A pre-install hook provisions a certificate into the same namespace using a format compatible with provisioning using end-user certificates. If the certificate already exists, the hook exits.
+2. The prometheus operator pod is configured to use a TLS proxy container, which will load that certificate.
+3. Validating and Mutating webhook configurations are created in the cluster, with their failure mode set to Ignore. This allows rules to be created by the same chart at the same time, even though the webhook has not yet been fully set up - it does not have the correct CA field set.
+4. A post-install hook reads the CA from the secret created by step 1 and patches the Validating and Mutating webhook configurations. This process will allow a custom CA provisioned by some other process to also be patched into the webhook configurations. The chosen failure policy is also patched into the webhook configurations
+
+### Alternatives
+
+It should be possible to use [jetstack/cert-manager](https://github.com/jetstack/cert-manager) if a more complete solution is required, but it has not been tested.
+
+### Limitations
+
+Because the operator can only run as a single pod, there is potential for this component failure to cause rule deployment failure. Because this risk is outweighed by the benefit of having validation, the feature is enabled by default.
+
+## Further Information
+
+For more in-depth documentation of configuration options meanings, please see
+
+- [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator)
+- [Prometheus](https://prometheus.io/docs/introduction/overview/)
+- [Grafana](https://github.com/grafana/helm-charts/tree/main/charts/grafana#grafana-helm-chart)
+
+## prometheus.io/scrape
+
+The prometheus operator does not support annotation-based discovery of services, using the `PodMonitor` or `ServiceMonitor` CRD in its place as they provide far more configuration options.
+For information on how to use PodMonitors/ServiceMonitors, please see the documentation on the `prometheus-operator/prometheus-operator` documentation here:
+
+- [ServiceMonitors](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/getting-started.md#include-servicemonitors)
+- [PodMonitors](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/getting-started.md#include-podmonitors)
+- [Running Exporters](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/running-exporters.md)

--- a/charts/nextjs/ci/default-values.yaml
+++ b/charts/nextjs/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# Leave this file empty to ensure that CI runs builds against the default configuration in values.yaml.

--- a/charts/nextjs/ci/with-ingress-values.yaml
+++ b/charts/nextjs/ci/with-ingress-values.yaml
@@ -1,0 +1,6 @@
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  host: nextjs.domain.com
+  path: /nextjs

--- a/charts/nextjs/ci/with-tolerations-values.yaml
+++ b/charts/nextjs/ci/with-tolerations-values.yaml
@@ -1,0 +1,4 @@
+tolerations:
+  - key: CiTest
+    operator: Exists
+    effect: NoSchedule

--- a/charts/nextjs/templates/NOTES.txt
+++ b/charts/nextjs/templates/NOTES.txt
@@ -1,0 +1,2 @@
+{{ $.Chart.Name }} has been installed. Check its status by running:
+  kubectl --namespace {{ template "chart.namespace" . }} get pods -l "release={{ $.Release.Name }}"

--- a/charts/nextjs/templates/_helpers.tpl
+++ b/charts/nextjs/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "chart.labels" -}}
+helm.sh/chart: {{ include "chart.chart" . }}
+{{ include "chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "chart.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/nextjs/templates/nextjs/deployment.yaml
+++ b/charts/nextjs/templates/nextjs/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    app: {{ template "chart.name" . }}
+    {{- include "chart.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "chart.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ include "chart.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end -}}

--- a/charts/nextjs/templates/nextjs/ingress.yaml
+++ b/charts/nextjs/templates/nextjs/ingress.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    app: {{ template "chart.name" . }}
+    {{- include "chart.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ .Values.ingress.tls }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path | quote }}
+            backend:
+              serviceName: {{ include "chart.fullname" . }}
+              servicePort: 3000
+{{- end -}}

--- a/charts/nextjs/templates/nextjs/service.yaml
+++ b/charts/nextjs/templates/nextjs/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3000
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "chart.selectorLabels" . | nindent 4 }}

--- a/charts/nextjs/values.yaml
+++ b/charts/nextjs/values.yaml
@@ -1,0 +1,59 @@
+# Default values for nextjs.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+## Provide a name in place of nextjs for `app:` labels
+##
+nameOverride: ""
+
+## Override the deployment namespace
+##
+namespaceOverride: ""
+
+## Provide a name to substitute for the full names of resources
+##
+fullnameOverride: ""
+
+## Initial replica count for the deployment
+##
+replicaCount: 1
+
+## Image containing the NextJS application
+##
+image:
+  repository: ellisio/nextjs
+  tag: "10.0.5"
+  pullPolicy: IfNotPresent
+
+## Application ingress
+##
+ingress:
+  enabled: false
+
+  ## Ingress class name (Enable to use on Kubernetes >= 1.18)
+  ##
+  # ingressClassName: nginx
+
+  ## Annotations for the ingress (TODO: use ingressClassName for Kubernetes >= 1.18)
+  ##
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+
+  ## Hosts to use for the ingress
+  ##
+  host: nextjs.domain.com
+
+  ## Path to use for ingress rules
+  ##
+  path: /
+
+  ## TLS configurations for the Ingress
+  ##
+  # tls: nextjs-tls
+
+## Tolerations for the pods
+##
+tolerations: []
+  # - key: foo
+  #   operator: Exists
+  #   effect: PreferNoSchedule

--- a/ct.yaml
+++ b/ct.yaml
@@ -5,5 +5,8 @@ chart-dirs:
   - charts
 chart-repos:
   - fluidshare=https://fluidshare.github.io/helm-charts
+  - prometheus-community=https://prometheus-community.github.io/helm-charts
+  - grafana=https://grafana.github.io/helm-charts
+  - stable=https://charts.helm.sh/stable
 helm-extra-args: --timeout 600s
 validate-maintainers: false


### PR DESCRIPTION
This adds the initial version of our `nextjs` chart. This can be used as a template for other simple web based applications. The image being used by default is a simple NextJS Docker image hosted on my personal docker. I'll move this image to `fluidshare` once I am added to the Docker Hub organization.