### PR TITLE
[locust] clean up configmaps

### DIFF
--- a/charts/locust/Chart.yaml
+++ b/charts/locust/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: locust
 description: A Helm chart to launch Locust tests.
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: 1.4.1

--- a/charts/locust/templates/NOTES.txt
+++ b/charts/locust/templates/NOTES.txt
@@ -1,11 +1,7 @@
 ## To access the locust master UI
 
 {{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.host }}
-  {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
-  {{- end }}
-{{- end }}
+  http://{{ .Values.ingress.host }}
 {{- else }}
 Run this command:
 

--- a/charts/locust/templates/configmap-locust-lib.yaml
+++ b/charts/locust/templates/configmap-locust-lib.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enableDefaultConfig -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,3 +7,4 @@ metadata:
     {{- include "chart.labels" . | nindent 4 }}
 data:
   {{- ($.Files.Glob (printf "locustfiles/%s/lib/*" .Values.loadtest.name)).AsConfig | nindent 2 }}
+{{- end -}}

--- a/charts/locust/templates/configmap-locust-locustfile.yaml
+++ b/charts/locust/templates/configmap-locust-locustfile.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enableDefaultConfig -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,3 +7,4 @@ metadata:
     {{- include "chart.labels" . | nindent 4 }}
 data:
   {{- ($.Files.Glob (printf "locustfiles/%s/main.py" .Values.loadtest.name)).AsConfig | nindent 2 }}
+{{- end -}}

--- a/charts/locust/values.yaml
+++ b/charts/locust/values.yaml
@@ -17,6 +17,10 @@ image:
   tag: 1.4.1
   pullPolicy: IfNotPresent
 
+## Set to false to disable the default config.
+##
+enableDefaultConfig: true
+
 ## The load test configuration.
 ##
 loadtest:


### PR DESCRIPTION
These should be disabled on our custom installs.