### PR TITLE
[nextjs] use tpl for hostname

### DIFF
--- a/charts/nextjs/Chart.yaml
+++ b/charts/nextjs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nextjs
 description: A chart for NextJS v10+.
 icon: https://cdn.worldvectorlogo.com/logos/next-js.svg
-version: 2.0.0
+version: 2.0.1
 appVersion: 10.0.5
 type: application
 keywords:

--- a/charts/nextjs/ci/with-ingress-and-hpa-values.yaml
+++ b/charts/nextjs/ci/with-ingress-and-hpa-values.yaml
@@ -1,5 +1,6 @@
 ingress:
   enabled: true
+  hostname: "{{ .Release.Name }}.local"
 
 hpa:
   enabled: true

--- a/charts/nextjs/templates/ingress.yaml
+++ b/charts/nextjs/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   rules:
     {{- if .Values.ingress.hostname }}
-    - host: {{ .Values.ingress.hostname }}
+    - host: {{ tpl .Values.ingress.hostname . | quote }}
       http:
         paths:
           {{- if .Values.ingress.extraPaths }}
@@ -33,7 +33,7 @@ spec:
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
-    - host: {{ .name | quote }}
+    - host: {{ tpl .name . | quote }}
       http:
         paths:
           - path: {{ default "/" .path }}


### PR DESCRIPTION
This enables the usage of template values in the hostname; which we use for our dynamic deployments on apps.