### PR TITLE
[nextjs] fix cluster issuer

### DIFF
--- a/charts/nextjs/Chart.yaml
+++ b/charts/nextjs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nextjs
 description: A chart for NextJS v10+.
 icon: https://cdn.worldvectorlogo.com/logos/next-js.svg
-version: 2.1.1
+version: 2.1.2
 appVersion: 10.0.5
 type: application
 keywords:

--- a/charts/nextjs/ci/with-ingress-and-hpa-values.yaml
+++ b/charts/nextjs/ci/with-ingress-and-hpa-values.yaml
@@ -2,6 +2,7 @@ ingress:
   enabled: true
   clusterIssuer: "testing"
   hostname: "{{ .Release.Name }}.local"
+  tls: true
 
 hpa:
   enabled: true

--- a/charts/nextjs/templates/ingress.yaml
+++ b/charts/nextjs/templates/ingress.yaml
@@ -46,11 +46,11 @@ spec:
   tls:
     {{- if .Values.ingress.tls }}
     - hosts:
-        - {{ .Values.ingress.hostname }}
-        {{- range .Values.ingress.extraHosts }}
-        - {{ .name }}
-        {{- end }}
-      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+      - {{ tpl .Values.ingress.hostname . | quote }}
+      {{- range .Values.ingress.extraHosts }}
+      - {{ .name }}
+      {{- end }}
+      secretName: {{ printf "%s-tls" (tpl .Values.ingress.hostname .) | replace "." "-" }}
     {{- end }}
     {{- if .Values.ingress.extraTls }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.extraTls "context" $ ) | nindent 4 }}


### PR DESCRIPTION
Use `tpl` for the TLS hostnames as well.