### PR TITLE
[golang] add redis dependency

### DIFF
--- a/.github/ct-install.yaml
+++ b/.github/ct-install.yaml
@@ -6,6 +6,7 @@ chart-dirs:
 excluded-charts:
   - common
 chart-repos:
+  - bitnami=https://charts.bitnami.com/bitnami
   - fluidshare=https://fluidshare.github.io/helm-charts
   - prometheus-community=https://prometheus-community.github.io/helm-charts
   - grafana=https://grafana.github.io/helm-charts

--- a/.github/ct-lint.yaml
+++ b/.github/ct-lint.yaml
@@ -5,6 +5,7 @@ debug: true
 chart-dirs:
   - charts
 chart-repos:
+  - bitnami=https://charts.bitnami.com/bitnami
   - fluidshare=https://fluidshare.github.io/helm-charts
   - prometheus-community=https://prometheus-community.github.io/helm-charts
   - grafana=https://grafana.github.io/helm-charts

--- a/charts/golang/Chart.lock
+++ b/charts/golang/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: common
   repository: https://fluidshare.github.io/helm-charts
   version: 1.1.0
-digest: sha256:6bb784691e8561a730d93495106cf7c01dc80a53cfb689d58e237e1c951f8842
-generated: "2021-01-21T15:16:33.754214-07:00"
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 12.7.3
+digest: sha256:20f735dfca6d69f8bfb1bfe45a5b115c5ad5320f31332c64fd542081edec113b
+generated: "2021-02-08T09:36:55.915465-07:00"

--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 1.0.0
+version: 1.1.0
 appVersion: 4.1.17
 type: application
 keywords:
@@ -16,3 +16,9 @@ dependencies:
     tags:
       - fluidshare-common
     version: 1.x.x
+  - name: redis
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - redis
+    version: "12.7.3"
+    condition: redis.enabled

--- a/charts/golang/ci/with-redis-wait.yaml
+++ b/charts/golang/ci/with-redis-wait.yaml
@@ -1,0 +1,4 @@
+redis:
+  enabled: true
+  password: password
+  wait: true

--- a/charts/golang/ci/with-redis.yaml
+++ b/charts/golang/ci/with-redis.yaml
@@ -1,0 +1,3 @@
+redis:
+  enabled: true
+  password: password

--- a/charts/golang/templates/_helpers.tpl
+++ b/charts/golang/templates/_helpers.tpl
@@ -24,3 +24,25 @@ Compile all warnings into a single message, and call fail.
 {{-   printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
 {{- end -}}\
 {{- end -}}
+
+{{/*
+Print "true" the wait-for-redis should be used.
+Usage:
+{{ include "golang.waitForRedis" . }}
+*/}}
+{{- define "golang.waitForRedis" -}}
+{{- if and (eq .Values.redis.enabled true) (eq .Values.redis.wait true) (.Values.redis.password) -}}
+{{- print "true" -}}
+{{- else -}}
+{{- print "false" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Print hostname for the redis service.
+Usage:
+{{ include "golang.redisHost" . }}
+*/}}
+{{- define "golang.redisHost" -}}
+{{- printf "%s-redis-master.%s.svc.cluster.local" .Release.Name .Release.Namespace | quote -}}
+{{- end -}}

--- a/charts/golang/templates/deployment.yaml
+++ b/charts/golang/templates/deployment.yaml
@@ -45,6 +45,23 @@ spec:
       {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}
+      {{- if eq "true" (include "golang.waitForRedis" .) }}
+      initContainers:
+        - name: wait-for-redis
+          image: redis:alpine
+          env:
+            - name: REDIS_HOST
+              value: {{ include "golang.redisHost" . }}
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDISCLI_AUTH
+              value: {{ .Values.redis.password | quote }}
+          args:
+            - /mnt/redis/wait-for-redis.sh
+          volumeMounts:
+            - name: wait-for-redis
+              mountPath: /mnt/redis
+      {{- end }}
       containers:
         - name: nextjs
           image: {{ template "nextjs.image" . }}
@@ -52,6 +69,27 @@ spec:
           {{- if .Values.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
+          env:
+            {{- if .Values.redis.enabled }}
+            - name: REDIS_HOST
+              value: {{ include "golang.redisHost" . }}
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_PASSWORD
+              value: {{ .Values.redis.password | quote }}
+            {{- end }}
+            {{- if .Values.envVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.envVars "context" $) | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- if .Values.envVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.envVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.envVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.envVarsSecret "context" $) }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.applicationPort }}
@@ -83,3 +121,10 @@ spec:
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
+      {{- if eq "true" (include "golang.waitForRedis" .) }}
+      volumes:
+        - name: wait-for-redis
+          configMap:
+            name: {{ template "common.names.fullname" . }}-wait-for-redis
+            defaultMode: 0777
+      {{- end }}

--- a/charts/golang/templates/redis/wait-for-redis.yaml
+++ b/charts/golang/templates/redis/wait-for-redis.yaml
@@ -1,0 +1,31 @@
+{{- if eq "true" (include "golang.waitForRedis" .) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "common.names.fullname" . }}-wait-for-redis
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+data:
+  wait-for-redis.sh: |
+    #/bin/sh
+
+    set -x;
+    echo "Waiting for Redis on ${REDIS_HOST}:${REDIS_PORT}"
+
+    ATTEMPTS=0
+
+    until [[ $(redis-cli -h "${REDIS_HOST}" -p "${REDIS_PORT}" ping) == "PONG" ]]; do
+      if [ $ATTEMPTS -gt 500 ]; then
+        echo "Failed to connect to Redis."
+        exit 1
+      fi
+
+      ATTEMPTS=$(($ATTEMPTS+1))
+      echo "Still waiting..."
+      sleep 1
+    done
+
+    echo "Connected to Redis!"
+{{- end }}

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -99,6 +99,21 @@ readinessProbe:
 ##
 priorityClassName: ""
 
+## An array to add extra env vars
+## For example:
+##
+envVars: []
+#  - name: BEARER_AUTH
+#    value: true
+
+## ConfigMap with extra environment variables
+##
+envVarsCM:
+
+## Secret with extra environment variables
+##
+envVarsSecret:
+
 ## SecurityContext configuration
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 ##
@@ -297,3 +312,13 @@ hpa:
   ## HPA annotations done as key:value pairs
   ##
   annotations: {}
+
+## Configure the redis service
+## ref: https://github.com/bitnami/charts/blob/master/bitnami/redis/values.yaml
+##
+redis:
+  enabled: false
+  password: ""
+  wait: false
+  cluster:
+    enabled: false


### PR DESCRIPTION
This adds the ability to enable a Redis service within the installation via `--set redis.enabled=true`. This is installing a `bitnami/redis` instance, with the `cluster` feature disabled.

The purpose of this is to add Redis to each PR environment since we don't want to spin up several Memorystore instances.