### PR TITLE
[golang] fix redis password

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 1.1.0
+version: 1.1.1
 appVersion: 4.1.17
 type: application
 keywords:

--- a/charts/golang/templates/deployment.yaml
+++ b/charts/golang/templates/deployment.yaml
@@ -55,7 +55,10 @@ spec:
             - name: REDIS_PORT
               value: "6379"
             - name: REDISCLI_AUTH
-              value: {{ .Values.redis.password | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-redis
+                  key: redis-password
           args:
             - /mnt/redis/wait-for-redis.sh
           volumeMounts:
@@ -76,7 +79,10 @@ spec:
             - name: REDIS_PORT
               value: "6379"
             - name: REDIS_PASSWORD
-              value: {{ .Values.redis.password | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-redis
+                  key: redis-password
             {{- end }}
             {{- if .Values.envVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.envVars "context" $) | nindent 12 }}


### PR DESCRIPTION
Instead of passing a clear text password to the k8s resource, mount the value from the secret, so it can be changed from `password`.