### PR TITLE
[golang] replace nextjs references with golang

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 1.1.1
+version: 1.1.2
 appVersion: 4.1.17
 type: application
 keywords:

--- a/charts/golang/templates/NOTES.txt
+++ b/charts/golang/templates/NOTES.txt
@@ -25,4 +25,4 @@
 
 {{- end }}
 
-{{- include "nextjs.validateValues" . }}
+{{- include "golang.validateValues" . }}

--- a/charts/golang/templates/_helpers.tpl
+++ b/charts/golang/templates/_helpers.tpl
@@ -1,21 +1,21 @@
 {{/*
 Return the proper NextJS image name
 */}}
-{{- define "nextjs.image" -}}
+{{- define "golang.image" -}}
 {{- include "common.images.image" (dict "imageRoot" .Values.image) -}}
 {{- end -}}
 
 {{/*
 Return the proper Docker Image Registry Secret Names
 */}}
-{{- define "nextjs.imagePullSecrets" -}}
+{{- define "golang.imagePullSecrets" -}}
 {{- include "common.images.pullSecrets" (dict "images" (list .Values.image)) -}}
 {{- end -}}
 
 {{/*
 Compile all warnings into a single message, and call fail.
 */}}
-{{- define "nextjs.validateValues" -}}
+{{- define "golang.validateValues" -}}
 {{- $messages := list -}}
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}

--- a/charts/golang/templates/deployment.yaml
+++ b/charts/golang/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
     spec:
-      {{- include "nextjs.imagePullSecrets" . | nindent 6 }}
+      {{- include "golang.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- end }}
@@ -66,8 +66,8 @@ spec:
               mountPath: /mnt/redis
       {{- end }}
       containers:
-        - name: nextjs
-          image: {{ template "nextjs.image" . }}
+        - name: app
+          image: {{ template "golang.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           {{- if .Values.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 ## NextJS image version
-## ref: https://hub.docker.com/r/ellisio/nextjs/tags/
+## ref: https://hub.docker.com/r/ellisio/goecho/tags/
 ##
 image:
   registry: docker.io
@@ -228,7 +228,7 @@ ingress:
 
   ## When the ingress is enabled, a host pointing to this will be created
   ##
-  hostname: nextjs.local
+  hostname: golang.local
 
   ## The Path to Node.js. You may need to set this to '/*' in order to use this
   ## with ALB ingress controllers.


### PR DESCRIPTION
@tofluid found some references to `nextjs` in this chart. This cleans all that up.