### PR TITLE
[golang] add frontendconfig for tls

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 1.3.0
+version: 1.4.0
 appVersion: 4.1.17
 type: application
 keywords:

--- a/charts/golang/templates/frontendconfig.yaml
+++ b/charts/golang/templates/frontendconfig.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.ingress.tls .Values.ingress.forceHttps }}
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
+kind: FrontendConfig
+metadata:
+  name: force-https
+spec:
+  redirectToHttps:
+    enabled: true
+{{- end }}

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -263,6 +263,10 @@ ingress:
   ##
   tls: false
 
+  ## Enable forced HTTP -> HTTPS redirection.
+  ##
+  forceHttps: false
+
   ## The list of additional hostnames to be covered with this ingress record.
   ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
   ## extraHosts:


### PR DESCRIPTION
This adds the `force-https` frontend config for GCE LBs.