### PR TITLE
[golang] modify envVars structure

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 1.4.1
+version: 2.0.0
 appVersion: 4.1.17
 type: application
 keywords:

--- a/charts/golang/ci/with-envvars.yaml
+++ b/charts/golang/ci/with-envvars.yaml
@@ -1,0 +1,11 @@
+envVars:
+  BOOLEAN_TEST: true
+  NUMBER_TEST: 99
+  FLOAT_TEST: 0.2
+  STRING_TEST: "test"
+  TEMPLATE_TEST: "{{ .Release.Name }}-test"
+  OBJECT_TEST:
+    valueFrom:
+      secretKeyRef:
+        name: test
+        key: test

--- a/charts/golang/templates/deployment.yaml
+++ b/charts/golang/templates/deployment.yaml
@@ -84,8 +84,13 @@ spec:
                   name: {{ .Release.Name }}-redis
                   key: redis-password
             {{- end }}
-            {{- if .Values.envVars }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.envVars "context" $) | nindent 12 }}
+            {{- range $key, $value := .Values.envVars }}
+            - name: {{ $key }}
+              {{- if or (typeIs "string" $value) (typeIs "float64" $value) (typeIs "bool" $value) }}
+              value: {{ include "common.tplvalues.render" (dict "value" $value "context" $) }}
+              {{- else }}
+              {{- include "common.tplvalues.render" (dict "value" $value "context" $) | nindent 14 }}
+              {{- end }}
             {{- end }}
           envFrom:
             {{- if .Values.envVarsCM }}

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -102,9 +102,14 @@ priorityClassName: ""
 ## An array to add extra env vars
 ## For example:
 ##
-envVars: []
-#  - name: BEARER_AUTH
-#    value: true
+envVars: {}
+  # BEARER_AUTH: true
+  # OTHER_VAR: "foo"
+  # SOME_PASSWORD:
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: some-ref
+  #       key: redis-password
 
 ## ConfigMap with extra environment variables
 ##


### PR DESCRIPTION
This changes the `envVars` structure so we can squash environment variables between environments.

`chart/common.yaml`:
```yaml
envVars:
  FOO: bar
```

`chart/dev.yaml`:
```yaml
envVars:
  CAT: meow
```

`chart/stage.yaml`:
```yaml
envVars:
  DOG: woof
```

### Outputs

`dev`:
```yaml
env:
  - name: FOO
    value: BAR
  - name: CAT
    value: meow
```

`stage`:
```yaml
env:
  - name: FOO
    value: BAR
  - name: DOG
    value: woof
```