### PR TITLE
[golang] allow custom images for cronjobs

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 2.2.1
+version: 2.3.0
 appVersion: 4.1.17
 type: application
 keywords:

--- a/charts/golang/ci/with-cronjobs-custom-image-values.yaml
+++ b/charts/golang/ci/with-cronjobs-custom-image-values.yaml
@@ -1,0 +1,9 @@
+cronjobs:
+  - name: hello
+    schedule: "*/1 * * * *"
+    image:
+      registry: docker.io
+      repository: busybox
+      tag: latest
+    command:
+      - date; echo Hello

--- a/charts/golang/templates/cronjob.yaml
+++ b/charts/golang/templates/cronjob.yaml
@@ -71,8 +71,13 @@ spec:
           {{- end }}
           containers:
           - name: {{ .name | quote }}
+            {{- if hasKey . "image" }}
+            image: {{ include "common.images.image" (dict "imageRoot" .image) }}
+            imagePullPolicy: {{ .image.pullPolicy | quote }}
+            {{- else }}
             image: {{ template "golang.image" $top }}
             imagePullPolicy: {{ $top.Values.image.pullPolicy | quote }}
+            {{- end }}
             {{- if typeIs "string" .command }}
             command:
               - sh

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -343,14 +343,20 @@ hpa:
 ## CronJob Parameters
 ##
 # cronjobs:
-  # - name: hello
-  #   schedule: "*/1 * * * *"
-  #   command:
-  #     - date; echo Hello
-  #   successfulJobsHistoryLimit: 0
-  #   failedJobsHistoryLimit: 0
-  #   lifecyle: {}
-  #   resources: {}
+#   - name: hello
+#     schedule: "*/1 * * * *"
+#     # image:
+#       # registry: docker.io
+#       # repository: ellisio/goecho
+#       # tag: "4.1.17"
+#       # # pullSecrets:
+#       # #   - myRegistryKeySecretName
+#     command:
+#       - date; echo Hello
+#     successfulJobsHistoryLimit: 0
+#     failedJobsHistoryLimit: 0
+#     lifecyle: {}
+#     resources: {}
 
 ## Configure the postgresql service
 ## ref: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml


### PR DESCRIPTION
This allows defining custom images for cronjobs, like so:

```yaml
cronjobs:
  - name: hello
    schedule: "*/1 * * * *"
    image:
      registry: docker.io
      repository: busybox
      tag: latest
    command:
      - date; echo Hello
```