### PR TITLE
[golang] fix missing grpc ingress path

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 2.3.1
+version: 2.3.2
 appVersion: 4.1.17
 type: application
 keywords:

--- a/charts/golang/ci/with-grpc-values.yaml
+++ b/charts/golang/ci/with-grpc-values.yaml
@@ -1,3 +1,7 @@
-grpc:
+ingress:
   enabled: true
-  port: 8090
+
+service:
+  grpc:
+    enabled: true
+    port: 8090

--- a/charts/golang/templates/ingress.yaml
+++ b/charts/golang/templates/ingress.yaml
@@ -31,6 +31,13 @@ spec:
             pathType: {{ .Values.ingress.pathType }}
             {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
+          {{- if .Values.service.grpc.enabled }}
+          - path: {{ .Values.ingress.path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "grpc" "context" $)  | nindent 14 }}
+          {{- end }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
     - host: {{ tpl .name . | quote }}


### PR DESCRIPTION
Enables the gRPC backend if the service has it enabled.