### PR TITLE
[golang] add grpc path setting

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 2.3.2
+version: 2.4.0
 appVersion: 4.1.17
 type: application
 keywords:

--- a/charts/golang/ci/with-grpc-values.yaml
+++ b/charts/golang/ci/with-grpc-values.yaml
@@ -4,4 +4,3 @@ ingress:
 service:
   grpc:
     enabled: true
-    port: 8090

--- a/charts/golang/templates/ingress.yaml
+++ b/charts/golang/templates/ingress.yaml
@@ -32,7 +32,7 @@ spec:
             {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
           {{- if .Values.service.grpc.enabled }}
-          - path: {{ .Values.ingress.path }}
+          - path: {{ .Values.service.grpc.path }}
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
             {{- end }}

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -183,15 +183,21 @@ service:
   ##
   port: 80
 
-  ## For defining a GRPC Port
+  ## gRPC Configuration
   ##
   grpc:
-    ## Set to true to enable grpc port
+    ## Set to true to enable gRPC
     ##
     enabled: false
-    ## GRCP Port
+
+    ## Port
     ##
     port: 8090
+
+    ## Path
+    ##
+    path: /grpc
+
     ## Specify the nodePort value for the LoadBalancer and NodePort service types.
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
     ##


### PR DESCRIPTION
This adds the `service.grpc.path` setting.